### PR TITLE
【Fixed】デバッグツールを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-rails'


### PR DESCRIPTION
#1

下記3つのデバッグツールをdevelopmentのみ反映されるようにした
・gem 'pry-rails'
・gem 'better_errors'
・gem 'binding_of_caller'