### PR TITLE
【Fixed】rails gコマンドの際にいらないファイルが生成されないように設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,5 +9,9 @@ module Sample
     config.load_defaults 5.2
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
#2

デフォルトで helperファイル と assets ファイルが生成されないようにした